### PR TITLE
Only consider WP session cookie for caching.

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -6,6 +6,11 @@
 "https://{default}/":
     type: upstream
     upstream: "app:http"
+    cache:
+      enable: true
+
+      # Base the cache on the session cookie. Ignore all other cookies.
+      cookies: ['/^wordpress_logged_in_*/']
 
 "https://www.{default}/":
     type: redirect


### PR DESCRIPTION
We already do this for Drupal, so let's do it for WP, too.