### PR TITLE
Adding SALT to README for wp-config-local.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,10 @@ define('DB_PASSWORD', "a strong password");
 define('DB_HOST', "127.0.0.1");
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
+
+# These will work locally, but feel free to change them/
+define('AUTH_KEY', 'SECURE_AUTH_KEY');
+define('LOGGED_IN_KEY', 'LOGGED_IN_SALT');
+define('NONCE_KEY', 'NONCE_SALT');
+define('AUTH_SALT', 'SECURE_AUTH_SALT');
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ define('DB_HOST', "127.0.0.1");
 define('DB_CHARSET', 'utf8');
 define('DB_COLLATE', '');
 
-# These will work locally, but feel free to change them/
+// These will be set automatically on Platform.sh to a different value, but that won't cause issues.
 define('AUTH_KEY', 'SECURE_AUTH_KEY');
 define('LOGGED_IN_KEY', 'LOGGED_IN_SALT');
 define('NONCE_KEY', 'NONCE_SALT');


### PR DESCRIPTION
I struggled with a infinite recursive issue with https://wordpress.org/plugins/w3-total-cache/ and the issues were the HALT missing.

I know it's not wordpress dependent but being that this was an issue for me, at least this will prevent the same issue and maybe others to crop up.